### PR TITLE
Crop Image

### DIFF
--- a/lib/transformations.dart
+++ b/lib/transformations.dart
@@ -3,5 +3,6 @@ library transformations;
 export 'transformations/adjust_color.dart';
 export 'transformations/brightness.dart';
 export 'transformations/contrast.dart';
+export 'transformations/crop.dart';
 export 'transformations/flip.dart';
 export 'transformations/resize.dart';

--- a/lib/transformations/crop.dart
+++ b/lib/transformations/crop.dart
@@ -5,23 +5,23 @@ import '../bitmap.dart';
 /// Crops the source bitmap to rectangle defined by top, left, width and height.
 Bitmap cropLTWH(
   Bitmap bitmap,
-  int cropLeft,
-  int cropTop,
-  int cropWidth,
-  int cropHeight,
+  int left,
+  int top,
+  int width,
+  int height,
 ) {
-  assert(cropLeft >= 0);
-  assert(cropTop >= 0);
-  assert(cropWidth > 0);
-  assert(cropHeight > 0);
-  assert(cropLeft + cropWidth <= bitmap.width);
-  assert(cropTop + cropHeight <= bitmap.height);
+  assert(left >= 0);
+  assert(top >= 0);
+  assert(width > 0);
+  assert(height > 0);
+  assert(left + width <= bitmap.width);
+  assert(top + height <= bitmap.height);
 
-  final int newBitmapSize = cropWidth * cropHeight * bitmapPixelLength;
+  final int newBitmapSize = width * height * bitmapPixelLength;
 
   final Bitmap cropped = Bitmap.fromHeadless(
-    cropWidth,
-    cropHeight,
+    width,
+    height,
     Uint8List(newBitmapSize),
   );
 
@@ -29,10 +29,10 @@ Bitmap cropLTWH(
     bitmap.content,
     cropped.content,
     bitmap.width, // Height is not needed.
-    cropLeft,
-    cropTop,
-    cropWidth,
-    cropHeight,
+    left,
+    top,
+    width,
+    height,
   );
 
   return cropped;

--- a/lib/transformations/crop.dart
+++ b/lib/transformations/crop.dart
@@ -41,17 +41,17 @@ Bitmap cropLTWH(
 /// Crops the source bitmap to rectangle defined by top, left, right and bottom.
 Bitmap cropLTRB(
   Bitmap bitmap,
-  int cropLeft,
-  int cropTop,
-  int cropRight,
-  int cropBottom,
+  int left,
+  int top,
+  int right,
+  int bottom,
 ) =>
     cropLTWH(
       bitmap,
-      cropLeft,
-      cropTop,
-      cropRight - cropLeft,
-      cropBottom - cropTop,
+      left,
+      top,
+      right - left,
+      bottom - top,
     );
 
 void cropCore(

--- a/lib/transformations/crop.dart
+++ b/lib/transformations/crop.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import '../bitmap.dart';
 
+/// Crops the source bitmap to rectangle defined by top, left, width and height.
 Bitmap cropLTWH(
   Bitmap bitmap,
   int cropLeft,
@@ -37,6 +38,7 @@ Bitmap cropLTWH(
   return cropped;
 }
 
+/// Crops the source bitmap to rectangle defined by top, left, right and bottom.
 Bitmap cropLTRB(
   Bitmap bitmap,
   int cropLeft,

--- a/lib/transformations/crop.dart
+++ b/lib/transformations/crop.dart
@@ -1,0 +1,74 @@
+import 'dart:typed_data';
+
+import '../bitmap.dart';
+
+Bitmap cropLTWH(
+  Bitmap bitmap,
+  int cropLeft,
+  int cropTop,
+  int cropWidth,
+  int cropHeight,
+) {
+  assert(cropLeft >= 0);
+  assert(cropTop >= 0);
+  assert(cropWidth > 0);
+  assert(cropHeight > 0);
+  assert(cropLeft + cropWidth <= bitmap.width);
+  assert(cropTop + cropHeight <= bitmap.height);
+
+  final int newBitmapSize = cropWidth * cropHeight * bitmapPixelLength;
+
+  final Bitmap cropped = Bitmap.fromHeadless(
+    cropWidth,
+    cropHeight,
+    Uint8List(newBitmapSize),
+  );
+
+  cropCore(
+    bitmap.content,
+    cropped.content,
+    bitmap.width, // Height is not needed.
+    cropLeft,
+    cropTop,
+    cropWidth,
+    cropHeight,
+  );
+
+  return cropped;
+}
+
+Bitmap cropLTRB(
+  Bitmap bitmap,
+  int cropLeft,
+  int cropTop,
+  int cropRight,
+  int cropBottom,
+) =>
+    cropLTWH(
+      bitmap,
+      cropLeft,
+      cropTop,
+      cropRight - cropLeft,
+      cropBottom - cropTop,
+    );
+
+void cropCore(
+  Uint8List sourceBmp,
+  Uint8List destBmp,
+  int sourceWidth,
+  int left,
+  int top,
+  int width,
+  int height,
+) {
+  for (int x = left * bitmapPixelLength;
+      x < (left + width) * bitmapPixelLength;
+      x++) {
+    for (int y = top; y < (top + height); y++) {
+      destBmp[x -
+              left * bitmapPixelLength +
+              (y - top) * width * bitmapPixelLength] =
+          sourceBmp[x + y * sourceWidth * bitmapPixelLength];
+    }
+  }
+}


### PR DESCRIPTION
I have implemented transformation that crops the source bitmap. There are two new methods:
- **`cropLTWH(bitmap, left, top, width, height)`** - crops to rectangle defined by top, left, width and height.
- **`cropLTRB(bitmap, left, top, right, bottom)`** - crops to rectangle defined by top, left, right and bottom.

I already use it in my own project and here is my use case. I have a bitmap of Minecraft skin and I needed this method to cut all the parts into separate images. 

Source bitmap:
<img src="https://user-images.githubusercontent.com/1166994/74233689-713b3880-4ccb-11ea-9bcc-47ac2f2bf9ec.png" width=256 />

After calling `cropTLWH(bmp, 8, 8, 8, 8)`:
<img src="https://user-images.githubusercontent.com/1166994/74233823-ba8b8800-4ccb-11ea-9527-95c7f9d473af.png" width=32 />
